### PR TITLE
move Perf args to public and remove getter / setters

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Open the documentation on your browser, from `/doc/html` directory:
 ```bash
 open index.html
 ```
+
 ---
 
 ## Profiling

--- a/include/types/Category.h
+++ b/include/types/Category.h
@@ -37,35 +37,6 @@ public:
   ~Category(){};
 
   /**
-   * Getter of category_id class attribute
-   *
-   * @return Category id
-   */
-  std::string getCategoryId() const;
-
-  /**
-   * Set a new value of category_id class attribute
-   *
-   * @param set_cat_id
-   *
-   */
-  void setCategoryId(std::string set_cat_id);
-
-  /**
-   * Getter of rank class attribute
-   * @return Category rank
-   */
-  int getCategoryRank() const;
-
-  /**
-   * Set a new value of rank class attribute
-   *
-   * @param set_rank
-   *
-   */
-  void setCategoryRank(int set_rank);
-
-  /**
    * Overloading << operator for Category class
    *
    * @param out ostream
@@ -83,7 +54,6 @@ public:
    */
   friend bool operator==(const Category &cat1, const Category &cat2);
 
-private:
   std::string category_id_;
   int rank_;
 };

--- a/include/types/Perf.h
+++ b/include/types/Perf.h
@@ -50,55 +50,12 @@ public:
   friend std::ostream &operator<<(std::ostream &out, const Perf &p);
 
   /**
-   * getName getter of name parameter
-   *
-   * @return name
-   */
-  std::string getName() const;
-
-  /**
-   * setName setter of name parameter
-   *
-   * @param name
-   */
-  void setName(std::string name);
-
-  /**
-   * getValue getter of value parameter
-   *
-   * @return value
-   */
-  float getValue() const;
-
-  /**
-   * setValue setter of value parameter
-   *
-   * @param value
-   */
-  void setValue(float value);
-
-  /**
-   * getCrit getter of crit parameter
-   *
-   * @return crit
-   */
-  std::string getCrit() const;
-
-  /**
-   * setCrit setter of crit parameter
-   *
-   * @param crit
-   */
-  void setCrit(std::string crit);
-
-  /**
    * Overload of == operator for Perf object
    *
    * @param perf2 Perf object to compare it with
    */
   bool operator==(const Perf &perf2) const;
 
-private:
   std::string crit_;
   float value_;
   std::string name_;

--- a/include/utils.h
+++ b/include/utils.h
@@ -161,7 +161,7 @@ randomCategoriesLimits(int nbCategories, unsigned long int seed = time(NULL)) {
 inline std::vector<std::string> getCriterionIds(std::vector<Perf> vectPerf) {
   std::vector<std::string> criterionIds;
   for (auto p : vectPerf) {
-    criterionIds.push_back(p.getCrit());
+    criterionIds.push_back(p.crit_);
   }
   return criterionIds;
 };
@@ -176,7 +176,7 @@ inline std::vector<std::string> getCriterionIds(std::vector<Perf> vectPerf) {
  */
 inline Perf getPerfOfCrit(std::vector<Perf> &vectPerf, std::string critId) {
   for (Perf p : vectPerf) {
-    if (p.getCrit() == critId) {
+    if (p.crit_ == critId) {
       return p;
     }
   }
@@ -193,7 +193,7 @@ inline Perf getPerfOfCrit(std::vector<Perf> &vectPerf, std::string critId) {
 inline std::vector<std::string> getNameIds(std::vector<Perf> vectPerf) {
   std::vector<std::string> NameIds;
   for (auto p : vectPerf) {
-    NameIds.push_back(p.getName());
+    NameIds.push_back(p.name_);
   }
   return NameIds;
 };
@@ -250,7 +250,7 @@ inline std::vector<Perf> createVectorPerfWithNoPerf(std::string id,
 inline std::vector<double> getPerfFromPerfVect(std::vector<Perf> &p) {
   std::vector<double> values;
   for (auto perf : p) {
-    values.push_back(static_cast<double>(perf.getValue()));
+    values.push_back(static_cast<double>(perf.value_));
   }
   return values;
 }
@@ -283,7 +283,7 @@ inline void plotGlobalData(AlternativesPerformance &ap) {
 
   std::set<int> cat_set;
   for (auto pair : map) {
-    cat_set.insert(pair.second.getCategoryRank());
+    cat_set.insert(pair.second.rank_);
   }
   // converting set to vector
   std::vector<int> ranks;
@@ -293,7 +293,7 @@ inline void plotGlobalData(AlternativesPerformance &ap) {
   std::unordered_map<int, int> index;
   int nbCriteria = 0;
   for (std::vector<Perf> p : ap.getPerformanceTable()) {
-    int rank = map[p[0].getName()].getCategoryRank();
+    int rank = map[p[0].name_].rank_;
     if (nbCriteria == 0)
       nbCriteria = p.size();
     // if we have already seen this category yet

--- a/src/learning/HeuristicPipeline.cpp
+++ b/src/learning/HeuristicPipeline.cpp
@@ -197,7 +197,7 @@ void HeuristicPipeline::computeAccuracy(MRSortModel &model) {
       model_assignments.getAlternativesAssignments();
   int acc = 0;
   for (std::pair<std::string, Category> e : assignments) {
-    if (e.second.getCategoryRank() == truth[e.first].getCategoryRank()) {
+    if (e.second.rank_ == truth[e.first].rank_) {
       acc++;
     }
   }

--- a/src/learning/ProfileUpdater.cpp
+++ b/src/learning/ProfileUpdater.cpp
@@ -37,7 +37,7 @@ std::unordered_map<float, float> ProfileUpdater::computeAboveDesirability(
   // to be sorted and in mode crit to have a meaniful iteration in the loop
   altPerf_model.sort();
   std::vector<Perf> alt_between =
-      altPerf_model.getAltBetween(critId, b.getValue(), b_above.getValue());
+      altPerf_model.getAltBetween(critId, b.value_, b_above.value_);
   // Initializing the map of desirability indexes
   std::unordered_map<float, float> desirability_above;
   float numerator = 0;
@@ -45,57 +45,55 @@ std::unordered_map<float, float> ProfileUpdater::computeAboveDesirability(
 
   for (Perf alt : alt_between) {
     // Checking if the move will not go above b_above
-    if (alt.getValue() + epsilon < b_above.getValue()) {
-      std::string altName = alt.getName();
+    if (alt.value_ + epsilon < b_above.value_) {
+      std::string altName = alt.name_;
       float conc = ct_prof[altName];
       float diff = conc - weight;
       std::string aa_data =
-          altPerf_data.getAlternativeAssignment(altName).getCategoryId();
+          altPerf_data.getAlternativeAssignment(altName).category_id_;
       std::string aa_model =
-          altPerf_model.getAlternativeAssignment(altName).getCategoryId();
+          altPerf_model.getAlternativeAssignment(altName).category_id_;
 
       // Here we are checking if the move of profile b right above/under the
       // performance of alt is going to help the model
-      if (aa_data == cat_above.getCategoryId()) {
+      if (aa_data == cat_above.category_id_) {
         // Correct classification
         // Moving the profile results in misclassification -> Q
-        if (aa_model == cat_above.getCategoryId() and diff < lambda) {
+        if (aa_model == cat_above.category_id_ and diff < lambda) {
           denominator += 5;
         }
         // Wrong classification
         // Moving the profile is in favor of wrong classification -> R
-        else if (aa_model == cat.getCategoryId()) {
+        else if (aa_model == cat.category_id_) {
           denominator += 1;
         }
-      } else if (aa_data == cat.getCategoryId() and
-                 aa_model == cat_above.getCategoryId()) {
+      } else if (aa_data == cat.category_id_ and
+                 aa_model == cat_above.category_id_) {
         // Wrong classification
         // Moving the profile is in favor of right classification -> W
         if (diff >= lambda) {
           numerator += 0.5;
           denominator += 1;
-          desirability_above[alt.getValue() + epsilon] =
-              numerator / denominator;
+          desirability_above[alt.value_ + epsilon] = numerator / denominator;
         }
         // Wrong classification
         // Moving the profile results in correct classification -> V
         else {
           numerator += 2;
           denominator += 1;
-          desirability_above[alt.getValue() + epsilon] =
-              numerator / denominator;
+          desirability_above[alt.value_ + epsilon] = numerator / denominator;
         }
       }
       // Wrong classification
       // Moving the profile is in favor of right classification -> T
       else if (aa_data != aa_model and
-               altPerf_model.getAlternativeAssignment(altName)
-                       .getCategoryRank() >= cat_above.getCategoryRank() and
-               altPerf_data.getAlternativeAssignment(altName)
-                       .getCategoryRank() < cat.getCategoryRank()) {
+               altPerf_model.getAlternativeAssignment(altName).rank_ >=
+                   cat_above.rank_ and
+               altPerf_data.getAlternativeAssignment(altName).rank_ <
+                   cat.rank_) {
         numerator += 0.1;
         denominator += 1;
-        desirability_above[alt.getValue() + epsilon] = numerator / denominator;
+        desirability_above[alt.value_ + epsilon] = numerator / denominator;
       }
     }
   }
@@ -117,7 +115,7 @@ std::unordered_map<float, float> ProfileUpdater::computeBelowDesirability(
   // to be sorted and in mode crit to have a meaniful iteration in the loop
   altPerf_model.sort();
   std::vector<Perf> alt_between =
-      altPerf_model.getAltBetween(critId, b_below.getValue(), b.getValue());
+      altPerf_model.getAltBetween(critId, b_below.value_, b.value_);
   // Initializing the map of desirability indexes
   std::unordered_map<float, float> desirability_below;
   float numerator = 0;
@@ -127,57 +125,54 @@ std::unordered_map<float, float> ProfileUpdater::computeBelowDesirability(
   for (int i = alt_between.size() - 1; i >= 0; i--) {
     Perf alt = alt_between[i];
     // Checking if the move will not go below b_below
-    if ((alt.getValue() - epsilon) > b_below.getValue()) {
-      std::string altName = alt.getName();
+    if ((alt.value_ - epsilon) > b_below.value_) {
+      std::string altName = alt.name_;
       float conc = ct_prof[altName];
       float diff = conc + weight;
       std::string aa_data =
-          altPerf_data.getAlternativeAssignment(altName).getCategoryId();
+          altPerf_data.getAlternativeAssignment(altName).category_id_;
       std::string aa_model =
-          altPerf_model.getAlternativeAssignment(altName).getCategoryId();
+          altPerf_model.getAlternativeAssignment(altName).category_id_;
 
       // Here we are checking if the move of profile b at the level of the
       // performance of alt is going to help the model
-      if (aa_data == cat_above.getCategoryId() and
-          aa_model == cat.getCategoryId()) {
+      if (aa_data == cat_above.category_id_ and aa_model == cat.category_id_) {
         // Wrong classification
         // Moving the profile results in correct classification -> V
         if (diff >= lambda) {
           numerator += 2;
           denominator += 1;
-          desirability_below[alt.getValue() - epsilon] =
-              numerator / denominator;
+          desirability_below[alt.value_ - epsilon] = numerator / denominator;
         }
         // Wrong classification
         // Moving the profile is in favor of right classification -> W
         else {
           numerator += 0.5;
           denominator += 1;
-          desirability_below[alt.getValue() - epsilon] =
-              numerator / denominator;
+          desirability_below[alt.value_ - epsilon] = numerator / denominator;
         }
-      } else if (aa_data == cat.getCategoryId()) {
+      } else if (aa_data == cat.category_id_) {
         // Correct classification
         // Moving the profile results in misclassification -> Q
-        if (aa_model == cat.getCategoryId() and diff >= lambda) {
+        if (aa_model == cat.category_id_ and diff >= lambda) {
           denominator += 5;
         }
         // Wrong classification
         // Moving the profile is in favor of wrong classification -> R
-        else if (aa_model == cat_above.getCategoryId()) {
+        else if (aa_model == cat_above.category_id_) {
           denominator += 1;
         }
       }
       // Wrong classification
       // Moving the profile is in favor of right classification -> T
       else if (aa_data != aa_model and
-               altPerf_model.getAlternativeAssignment(altName)
-                       .getCategoryRank() > cat.getCategoryRank() and
-               altPerf_data.getAlternativeAssignment(altName)
-                       .getCategoryRank() > cat.getCategoryRank()) {
+               altPerf_model.getAlternativeAssignment(altName).rank_ >
+                   cat.rank_ and
+               altPerf_data.getAlternativeAssignment(altName).rank_ >
+                   cat.rank_) {
         numerator += 0.1;
         denominator += 1;
-        desirability_below[alt.getValue() - epsilon] = numerator / denominator;
+        desirability_below[alt.value_ - epsilon] = numerator / denominator;
       }
     }
   }
@@ -202,8 +197,7 @@ void ProfileUpdater::updateTables(
     MRSortModel &model, std::string critId, Perf &b_old, Perf &b_new,
     std::unordered_map<std::string, std::unordered_map<std::string, float>> &ct,
     AlternativesPerformance &altPerf_model) {
-  if (b_old.getName() != b_new.getName() ||
-      b_old.getCrit() != b_new.getCrit()) {
+  if (b_old.name_ != b_new.name_ || b_old.crit_ != b_new.crit_) {
     throw std::invalid_argument("Profile perfs must have same name and crit");
   }
 
@@ -212,39 +206,39 @@ void ProfileUpdater::updateTables(
   // weight for the concordance and calculate alternatives between old profile
   // perf and new profile perf.
   std::vector<Perf> alt_between;
-  if (b_old.getValue() > b_new.getValue()) {
+  if (b_old.value_ > b_new.value_) {
     w = model.criteria[critId].getWeight();
     alt_between =
-        altPerf_model.getAltBetween(critId, b_new.getValue(), b_old.getValue());
+        altPerf_model.getAltBetween(critId, b_new.value_, b_old.value_);
   } else {
     w = -model.criteria[critId].getWeight();
     alt_between =
-        altPerf_model.getAltBetween(critId, b_old.getValue(), b_new.getValue());
+        altPerf_model.getAltBetween(critId, b_old.value_, b_new.value_);
   }
 
   for (Perf alt : alt_between) {
     // Data assignment
     std::string aa_data =
-        altPerf_data.getAlternativeAssignment(alt.getName()).getCategoryId();
+        altPerf_data.getAlternativeAssignment(alt.name_).category_id_;
     // Old assignmment
     std::string aa_old =
-        altPerf_model.getAlternativeAssignment(alt.getName()).getCategoryId();
+        altPerf_model.getAlternativeAssignment(alt.name_).category_id_;
 
     // Update concordance table
-    float c = ct[b_old.getName()][alt.getName()] + w;
-    ct[b_old.getName()][alt.getName()] = c;
+    float c = ct[b_old.name_][alt.name_] + w;
+    ct[b_old.name_][alt.name_] = c;
     // Update profile
-    model.profiles.setPerf(b_new.getName(), b_new.getCrit(), b_new.getValue());
+    model.profiles.setPerf(b_new.name_, b_new.crit_, b_new.value_);
 
     // New assignment
     altPerf_model.changeMode("alt");
-    auto alternative = altPerf_model.operator[](alt.getName());
+    auto alternative = altPerf_model.operator[](alt.name_);
     std::vector<std::vector<Perf>> pt = model.profiles.getPerformanceTable();
     Category cat_new = model.categoryAssignment(alternative, pt);
-    std::string aa_new = cat_new.getCategoryId();
+    std::string aa_new = cat_new.category_id_;
 
     // Update alternative assignment
-    altPerf_model.setAlternativeAssignment(alt.getName(), cat_new);
+    altPerf_model.setAlternativeAssignment(alt.name_, cat_new);
 
     // Update model score
     int n_alt = altPerf_data.getNumberAlt();
@@ -268,7 +262,7 @@ void ProfileUpdater::optimizeProfile(
   // the profile
   std::pair<float, float> bounds = altPerf_model.getBoundaries();
   std::pair<std::vector<Perf>, std::vector<Perf>> below_above =
-      model.profiles.getBelowAndAboveProfile(prof[0].getName(), bounds.first,
+      model.profiles.getBelowAndAboveProfile(prof[0].name_, bounds.first,
                                              bounds.second);
   std::vector<Perf> prof_below = below_above.first;
   std::vector<Perf> prof_above = below_above.second;
@@ -277,7 +271,7 @@ void ProfileUpdater::optimizeProfile(
     Perf b_below = getPerfOfCrit(prof_below, crit.getId());
     Perf b_above = getPerfOfCrit(prof_above, crit.getId());
 
-    std::unordered_map<std::string, float> ct_prof = ct[b.getName()];
+    std::unordered_map<std::string, float> ct_prof = ct[b.name_];
 
     std::unordered_map<float, float> below_des = this->computeBelowDesirability(
         model, crit.getId(), b, b_below, cat_below, cat_above, ct_prof,
@@ -293,7 +287,7 @@ void ProfileUpdater::optimizeProfile(
     float r = getRandomUniformFloat();
     if (r <= key_max) {
       Perf b_new = Perf(b);
-      b_new.setValue(key_max);
+      b_new.value_ = key_max;
       this->updateTables(model, crit.getId(), b, b_new, ct, altPerf_model);
     }
   }

--- a/src/learning/WeightUpdater.cpp
+++ b/src/learning/WeightUpdater.cpp
@@ -49,11 +49,10 @@ WeightUpdater::computeXMatrix(MRSortModel &model) {
     for (auto alt : alts_pt) {
       std::vector<bool> x_h_alt;
       // if alt is assigned to category h (otherwise, append empty vector)
-      if (ap.getAlternativeAssignment(alt[0].getName()).getCategoryRank() ==
-          h) {
+      if (ap.getAlternativeAssignment(alt[0].name_).rank_ == h) {
         for (int j = 0; j < alt.size(); j++) {
           // condition: aj >= bj_h-1
-          x_h_alt.push_back(alt[j].getValue() >= profs_pt[h - 1][j].getValue());
+          x_h_alt.push_back(alt[j].value_ >= profs_pt[h - 1][j].value_);
         }
       }
       x_h.push_back(x_h_alt);
@@ -75,11 +74,10 @@ WeightUpdater::computeYMatrix(MRSortModel &model) {
     for (auto alt : alts_pt) {
       std::vector<bool> y_h_alt;
       // if alt is assigned to category h (otherwise, append empty vector)
-      if (ap.getAlternativeAssignment(alt[0].getName()).getCategoryRank() ==
-          h) {
+      if (ap.getAlternativeAssignment(alt[0].name_).rank_ == h) {
         for (int j = 0; j < alt.size(); j++) {
           // condition: aj >= bj_h
-          y_h_alt.push_back(alt[j].getValue() >= profs_pt[h][j].getValue());
+          y_h_alt.push_back(alt[j].value_ >= profs_pt[h][j].value_);
         }
       }
       y_h.push_back(y_h_alt);
@@ -105,7 +103,7 @@ bool WeightUpdater::modelCheck(MRSortModel &model) {
   std::vector<std::vector<Perf>> profs = model.profiles.getPerformanceTable();
   auto ap_pt = ap.getPerformanceTable();
   for (int i = 0; i < ap.getNumberCrit(); i++) {
-    if (profs[0][i].getCrit() != ap_pt[0][i].getCrit()) {
+    if (profs[0][i].crit_ != ap_pt[0][i].crit_) {
       return false;
     }
   }

--- a/src/types/AlternativesPerformance.cpp
+++ b/src/types/AlternativesPerformance.cpp
@@ -16,7 +16,7 @@ AlternativesPerformance::AlternativesPerformance(
   }
   if (alt_assignment.empty()) {
     for (std::vector<Perf> pv : pt_) {
-      std::string altName = pv[0].getName();
+      std::string altName = pv[0].name_;
       alt_assignment_[altName] = default_cat;
     }
   } else {
@@ -41,7 +41,7 @@ AlternativesPerformance::AlternativesPerformance(
   }
   if (alt_assignment.empty()) {
     for (std::vector<Perf> pv : pt_) {
-      std::string altName = pv[0].getName();
+      std::string altName = pv[0].name_;
       alt_assignment_[altName] = default_cat;
     }
   } else {
@@ -66,7 +66,7 @@ AlternativesPerformance::AlternativesPerformance(
                               "assign default categories.");
     }
     for (std::vector<Perf> pv : pt_) {
-      std::string altName = pv[0].getName();
+      std::string altName = pv[0].name_;
       alt_assignment_[altName] = default_cat;
     }
   } else {
@@ -148,23 +148,23 @@ int AlternativesPerformance::getNumberCats() {
   std::vector<std::string> cat_vector;
   for (auto pair : alt_assignment_) {
     if (!std::count(cat_vector.begin(), cat_vector.end(),
-                    pair.second.getCategoryId())) {
-      cat_vector.push_back(pair.second.getCategoryId());
+                    pair.second.category_id_)) {
+      cat_vector.push_back(pair.second.category_id_);
     }
   }
   return cat_vector.size();
 }
 
 std::pair<float, float> AlternativesPerformance::getBoundaries() {
-  float min = pt_[0][0].getValue();
-  float max = pt_[0][0].getValue();
+  float min = pt_[0][0].value_;
+  float max = pt_[0][0].value_;
   for (int i = 0; i < pt_.size(); i++) {
     for (int j = 0; j < pt_[i].size(); j++) {
-      if (pt_[i][j].getValue() < min) {
-        min = pt_[i][j].getValue();
+      if (pt_[i][j].value_ < min) {
+        min = pt_[i][j].value_;
       }
-      if (pt_[i][j].getValue() > max) {
-        max = pt_[i][j].getValue();
+      if (pt_[i][j].value_ > max) {
+        max = pt_[i][j].value_;
       }
     }
   }

--- a/src/types/Categories.cpp
+++ b/src/types/Categories.cpp
@@ -43,7 +43,7 @@ Categories::~Categories() {
 std::vector<int> Categories::getRankCategories() {
   std::vector<int> rank_categories;
   for (int i = 0; i < categories_vector_.size(); i++) {
-    rank_categories.push_back(categories_vector_[i].getCategoryRank());
+    rank_categories.push_back(categories_vector_[i].rank_);
   }
   return rank_categories;
 }
@@ -54,27 +54,27 @@ void Categories::setRankCategories(std::vector<int> &set_ranks) {
         "RankCategories setter object is not the same size as Categories.");
   }
   for (int i = 0; i < set_ranks.size(); i++) {
-    categories_vector_[i].setCategoryRank(set_ranks[i]);
+    categories_vector_[i].rank_ = set_ranks[i];
   }
 }
 
 void Categories::setRankCategories() {
   for (int i = 0; i < categories_vector_.size(); i++) {
-    categories_vector_[i].setCategoryRank(i);
+    categories_vector_[i].rank_ = i;
   }
 }
 
 std::vector<std::string> Categories::getIdCategories() {
   std::vector<std::string> categories_ids;
   for (int i = 0; i < categories_vector_.size(); i++) {
-    categories_ids.push_back(categories_vector_[i].getCategoryId());
+    categories_ids.push_back(categories_vector_[i].category_id_);
   }
   return categories_ids;
 }
 
 void Categories::setIdCategories(std::string prefix) {
   for (int i = 0; i < categories_vector_.size(); i++) {
-    categories_vector_[i].setCategoryId(prefix + std::to_string(i));
+    categories_vector_[i].category_id_ = prefix + std::to_string(i);
   }
 }
 
@@ -84,13 +84,13 @@ void Categories::setIdCategories(std::vector<std::string> &set_category_ids) {
         "IdCategories setter object is not the same size as Categories.");
   }
   for (int i = 0; i < set_category_ids.size(); i++) {
-    categories_vector_[i].setCategoryId(set_category_ids[i]);
+    categories_vector_[i].category_id_ = set_category_ids[i];
   }
 }
 
 Category Categories::getCategoryOfRank(int rank) {
   for (Category cat : categories_vector_) {
-    if (cat.getCategoryRank() == rank) {
+    if (cat.rank_ == rank) {
       return cat;
     }
   }

--- a/src/types/Category.cpp
+++ b/src/types/Category.cpp
@@ -6,19 +6,9 @@ Category::Category(std::string cat_id, int cat_rank) {
 }
 
 Category::Category(const Category &cat) {
-  category_id_ = cat.getCategoryId();
-  rank_ = cat.getCategoryRank();
+  category_id_ = cat.category_id_;
+  rank_ = cat.rank_;
 }
-
-std::string Category::getCategoryId() const { return category_id_; }
-
-void Category::setCategoryId(std::string set_cat_id) {
-  category_id_ = set_cat_id;
-}
-
-int Category::getCategoryRank() const { return rank_; }
-
-void Category::setCategoryRank(int set_rank) { rank_ = set_rank; }
 
 std::ostream &operator<<(std::ostream &out, const Category &cat) {
 

--- a/src/types/DataGenerator.cpp
+++ b/src/types/DataGenerator.cpp
@@ -68,15 +68,15 @@ void DataGenerator::datasetGenerator(int nb_criteria, int nb_alternative,
 
     // getting alternative id
     alternative_node.append_child(pugi::node_pcdata)
-        .set_value(alternative[0].getName().c_str());
+        .set_value(alternative[0].name_.c_str());
 
     for (Perf perf : alternative) {
       // for each criteria give its correspondant performace
       pugi::xml_node alternative_criteria_node =
-          alternative_node.append_child(perf.getCrit().c_str());
+          alternative_node.append_child(perf.crit_.c_str());
 
       alternative_criteria_node.append_child(pugi::node_pcdata)
-          .set_value(std::to_string(perf.getValue()).c_str());
+          .set_value(std::to_string(perf.value_).c_str());
     }
 
     // Give the category assignemnt to the alternative
@@ -307,7 +307,7 @@ void DataGenerator::saveModel(std::string fileName, float lambda,
       profile_node.append_child(pugi::node_pcdata)
           .set_value(
               std::to_string(
-                  pt.getPerformanceTable()[nb_categories - j - 1][i].getValue())
+                  pt.getPerformanceTable()[nb_categories - j - 1][i].value_)
                   .c_str());
     }
 
@@ -434,16 +434,16 @@ void DataGenerator::saveDataset(std::string fileName,
     pugi::xml_node alternative_node = dataset_node.append_child("alternative");
     // getting alternative id
     alternative_node.append_child(pugi::node_pcdata)
-        .set_value(p[0].getName().c_str());
+        .set_value(p[0].name_.c_str());
 
     // looping over performance values of specific alternative
     for (Perf perf : p) {
       // for each criteria give its correspondant performace
       pugi::xml_node alternative_criteria_node =
-          alternative_node.append_child(perf.getCrit().c_str());
+          alternative_node.append_child(perf.crit_.c_str());
 
       alternative_criteria_node.append_child(pugi::node_pcdata)
-          .set_value(std::to_string(perf.getValue()).c_str());
+          .set_value(std::to_string(perf.value_).c_str());
     }
 
     // Get the category assignemnt of the alternative from altPerf
@@ -452,8 +452,7 @@ void DataGenerator::saveDataset(std::string fileName,
 
     alternative_assignment.append_child(pugi::node_pcdata)
         .set_value(
-            std::to_string(altPerf.getAlternativeAssignment(p[0].getName())
-                               .getCategoryRank())
+            std::to_string(altPerf.getAlternativeAssignment(p[0].name_).rank_)
                 .c_str());
   }
 

--- a/src/types/MRSortModel.cpp
+++ b/src/types/MRSortModel.cpp
@@ -82,7 +82,7 @@ AlternativesPerformance MRSortModel::categoryAssignments(PerformanceTable &pt) {
   std::vector<std::vector<Perf>> profiles_pt = profiles.getPerformanceTable();
   // Looping over all alternatives
   for (std::vector<Perf> alt : pt.getPerformanceTable()) {
-    cat_assignments[alt[0].getName()] = categoryAssignment(alt, profiles_pt);
+    cat_assignments[alt[0].name_] = categoryAssignment(alt, profiles_pt);
   }
   return AlternativesPerformance(pt, cat_assignments);
 }
@@ -95,9 +95,8 @@ float MRSortModel::computeConcordance(std::vector<Perf> &prof,
       // If the value of the alt on criterion j is greater than the one of
       // the profile h, add the weight of the criterion j to the concordance
       // value.
-      if ((prof_i.getCrit() == perf_j.getCrit()) &&
-          (perf_j.getValue() > prof_i.getValue())) {
-        c = c + criteria[perf_j.getCrit()].getWeight();
+      if ((prof_i.crit_ == perf_j.crit_) && (perf_j.value_ > prof_i.value_)) {
+        c = c + criteria[perf_j.crit_].getWeight();
       }
     }
   }
@@ -117,10 +116,9 @@ MRSortModel::computeConcordanceTable(PerformanceTable &pt) {
     std::unordered_map<std::string, float> prof_concordances;
     // Looping over all alternatives
     for (std::vector<Perf> alt : pt.getPerformanceTable()) {
-      prof_concordances[alt[0].getName()] =
-          computeConcordance(profiles_pt[h], alt);
+      prof_concordances[alt[0].name_] = computeConcordance(profiles_pt[h], alt);
     }
-    ct[profiles_pt[h][0].getName()] = prof_concordances;
+    ct[profiles_pt[h][0].name_] = prof_concordances;
   }
   return ct;
 }

--- a/src/types/Perf.cpp
+++ b/src/types/Perf.cpp
@@ -15,32 +15,20 @@ Perf::Perf(std::string name, std::string criterion) {
 }
 
 Perf::Perf(const Perf &perf) {
-  name_ = perf.getName();
-  crit_ = perf.getCrit();
-  value_ = perf.getValue();
+  name_ = perf.name_;
+  crit_ = perf.crit_;
+  value_ = perf.value_;
 }
 
 Perf::~Perf() {}
 
 std::ostream &operator<<(std::ostream &out, const Perf &p) {
-  out << "Perf( name : " << p.getName() << ", crit : " << p.getCrit()
-      << ", value : " << p.getValue() << " )";
+  out << "Perf( name : " << p.name_ << ", crit : " << p.crit_
+      << ", value : " << p.value_ << " )";
   return out;
 }
 
-std::string Perf::getName() const { return name_; }
-
-void Perf::setName(std::string name) { name_ = name; }
-
-float Perf::getValue() const { return value_; }
-
-void Perf::setValue(float value) { value_ = value; }
-
-std::string Perf::getCrit() const { return crit_; }
-
-void Perf::setCrit(std::string crit) { crit_ = crit; }
-
 bool Perf::operator==(const Perf &perf2) const {
-  return (this->crit_ == perf2.getCrit() && this->value_ == perf2.getValue() &&
-          this->name_ == perf2.getName());
+  return (this->crit_ == perf2.crit_ && this->value_ == perf2.value_ &&
+          this->name_ == perf2.name_);
 }

--- a/src/types/Profiles.cpp
+++ b/src/types/Profiles.cpp
@@ -66,7 +66,7 @@ void Profiles::generateRandomPerfValues(unsigned long int seed, int lower_bound,
       std::sort(r_vect.begin(), r_vect.end());
       std::reverse(r_vect.begin(), r_vect.end());
       for (int k = 0; k < nbProfiles; k++) {
-        pt_[nbProfiles - 1 - k][j].setValue(r_vect[k]);
+        pt_[nbProfiles - 1 - k][j].value_ = r_vect[k];
       }
     }
   } else {
@@ -80,7 +80,7 @@ void Profiles::generateRandomPerfValues(unsigned long int seed, int lower_bound,
       }
       std::sort(r_vect.begin(), r_vect.end());
       for (int k = 0; k < nbCat; k++) {
-        pt_[j][k].setValue(r_vect[k]);
+        pt_[j][k].value_ = r_vect[k];
       }
     }
   }
@@ -90,8 +90,7 @@ bool Profiles::isProfileOrdered() {
   if (mode_ == "crit") {
     for (int crit = 0; crit < pt_.size(); crit++) {
       for (int catLimit = 0; catLimit < pt_[crit].size() - 1; catLimit++) {
-        if (pt_[crit][catLimit].getValue() >
-            pt_[crit][catLimit + 1].getValue()) {
+        if (pt_[crit][catLimit].value_ > pt_[crit][catLimit + 1].value_) {
           return false;
         }
       }
@@ -100,7 +99,7 @@ bool Profiles::isProfileOrdered() {
   } else {
     for (int profile = 0; profile < pt_.size() - 1; profile++) {
       for (int crit = 0; crit < pt_[profile].size(); crit++) {
-        if (pt_[profile][crit].getValue() > pt_[profile + 1][crit].getValue()) {
+        if (pt_[profile][crit].value_ > pt_[profile + 1][crit].value_) {
           return false;
         }
       }
@@ -116,11 +115,11 @@ Profiles::getBelowAndAboveProfile(std::string profName, float worst_value,
   int n_crit = this->getNumberCrit();
   std::vector<Perf> base;
   for (int i = 0; i < n_crit; i++) {
-    base.push_back(Perf("base", pt_[0][i].getCrit(), worst_value));
+    base.push_back(Perf("base", pt_[0][i].crit_, worst_value));
   }
   std::vector<Perf> top;
   for (int i = 0; i < n_crit; i++) {
-    top.push_back(Perf("top", pt_[0][i].getCrit(), best_value));
+    top.push_back(Perf("top", pt_[0][i].crit_, best_value));
   }
   std::vector<Perf> below;
   std::vector<Perf> above;
@@ -129,7 +128,7 @@ Profiles::getBelowAndAboveProfile(std::string profName, float worst_value,
       return std::make_pair(base, top);
     }
     for (int h = 0; h < pt_.size(); h++) {
-      if (pt_[h][0].getName() == profName) {
+      if (pt_[h][0].name_ == profName) {
         if (h == 0) {
           below = base;
           above = pt_[h + 1];
@@ -157,10 +156,10 @@ void Profiles::setPerf(std::string name, std::string crit, float value) {
   // if in mode crit, each row contains 1 and only 1 criterion
   if (mode_ == "alt") {
     for (std::vector<Perf> &p : pt_) {
-      if (p[0].getName() == name) {
+      if (p[0].name_ == name) {
         for (Perf &perf : p) {
-          if (perf.getCrit() == crit) {
-            perf.setValue(value);
+          if (perf.crit_ == crit) {
+            perf.value_ = value;
             return;
           }
         }
@@ -170,10 +169,10 @@ void Profiles::setPerf(std::string name, std::string crit, float value) {
     throw std::invalid_argument("Name not found in performance table");
   } else if (mode_ == "crit") {
     for (std::vector<Perf> &p : pt_) {
-      if (p[0].getCrit() == crit) {
+      if (p[0].crit_ == crit) {
         for (Perf &perf : p) {
-          if (perf.getName() == name) {
-            perf.setValue(value);
+          if (perf.name_ == name) {
+            perf.value_ = value;
             return;
           }
         }

--- a/test/TestUtils.cpp
+++ b/test/TestUtils.cpp
@@ -39,7 +39,7 @@ TEST(TestUtils, TestUtilsGetPerfOfCrit) {
   std::vector<float> givenPerf = {1, 3, 4};
   std::vector<Perf> vecp = createVectorPerf(id, crit, givenPerf);
   Perf p = getPerfOfCrit(vecp, "crit1");
-  EXPECT_EQ(p.getValue(), 3);
+  EXPECT_EQ(p.value_, 3);
   try {
     Perf p = getPerfOfCrit(vecp, "crit6");
     FAIL() << "should have thrown invalid argument.";

--- a/test/learning/TestInitializeProfile.cpp
+++ b/test/learning/TestInitializeProfile.cpp
@@ -53,20 +53,20 @@ TEST(TestProfileInitializer, TestGetProfileCandidates) {
       profInit.getProfilePerformanceCandidates(crit[0], cat0, 3);
   std::vector<std::string> altId;
   for (auto p : candidates)
-    altId.push_back(p.getName());
+    altId.push_back(p.name_);
   std::sort(altId.begin(), altId.end());
-  EXPECT_EQ(candidates[0].getName(), "alt0");
-  EXPECT_EQ(candidates[1].getName(), "alt2");
-  EXPECT_EQ(candidates[2].getName(), "alt3");
+  EXPECT_EQ(candidates[0].name_, "alt0");
+  EXPECT_EQ(candidates[1].name_, "alt2");
+  EXPECT_EQ(candidates[2].name_, "alt3");
 
   std::vector<std::string> altId2;
   std::vector<Perf> candidates2 =
       profInit.getProfilePerformanceCandidates(crit[0], cat2, 3);
   for (auto p : candidates2)
-    altId2.push_back(p.getName());
+    altId2.push_back(p.name_);
   std::sort(altId2.begin(), altId2.end());
-  EXPECT_EQ(candidates2[0].getName(), "alt1");
-  EXPECT_EQ(candidates2[1].getName(), "alt3");
+  EXPECT_EQ(candidates2[0].name_, "alt1");
+  EXPECT_EQ(candidates2[1].name_, "alt3");
 }
 
 TEST(TestProfileInitializer, TestWeightedProbability) {

--- a/test/learning/TestProfileUpdater.cpp
+++ b/test/learning/TestProfileUpdater.cpp
@@ -108,8 +108,7 @@ TEST(TestProfileUpdater, TestComputeAboveDesirability) {
       profUpdater.computeAboveDesirability(model, "crit0", b0_c0, b1_c0, cat,
                                            cat_above, ct_b0, altPerf_model);
   EXPECT_FLOAT_EQ(
-      above_des[altPerf_data.getPerf("alt1", "crit0").getValue() + epsilon],
-      0.5);
+      above_des[altPerf_data.getPerf("alt1", "crit0").value_ + epsilon], 0.5);
 
   Perf b0_c3 = Perf("b0", "crit3", 0.3);
   Perf b1_c3 = Perf("b1", "crit3", 0.6);
@@ -117,7 +116,7 @@ TEST(TestProfileUpdater, TestComputeAboveDesirability) {
       profUpdater.computeAboveDesirability(model, "crit3", b0_c3, b1_c3, cat,
                                            cat_above, ct_b0, altPerf_model);
   EXPECT_FLOAT_EQ(
-      above_des_bis[altPerf_data.getPerf("alt1", "crit3").getValue() + epsilon],
+      above_des_bis[altPerf_data.getPerf("alt1", "crit3").value_ + epsilon],
       0.25);
 }
 
@@ -142,7 +141,7 @@ TEST(TestProfileUpdater, TestComputeBelowDesirability) {
       profUpdater.computeBelowDesirability(model, "crit1", b0_c1, base, cat,
                                            cat_above, ct_b0, altPerf_model);
   EXPECT_FLOAT_EQ(
-      below_des[altPerf_data.getPerf("alt2", "crit1").getValue() - epsilon], 2);
+      below_des[altPerf_data.getPerf("alt2", "crit1").value_ - epsilon], 2);
 }
 
 TEST(TestProfileUpdater, TestChooseMaxDesirability) {
@@ -189,15 +188,15 @@ TEST(TestProfileUpdater, TestUpdateTables) {
   profUpdater.updateTables(model, "crit1", b0_c1_old, b0_c1_new, ct,
                            altPerf_model);
   std::string new_cat =
-      altPerf_model.getAlternativeAssignment("alt2").getCategoryId();
+      altPerf_model.getAlternativeAssignment("alt2").category_id_;
   EXPECT_EQ(new_cat, "cat1");
 
   // Test update score
   EXPECT_FLOAT_EQ(0.5, model.getScore());
 
   // Test update profiles
-  EXPECT_FLOAT_EQ(model.profiles.getPerf("b0", "crit0").getValue(), 0.39);
-  EXPECT_FLOAT_EQ(model.profiles.getPerf("b0", "crit1").getValue(), 0.18);
+  EXPECT_FLOAT_EQ(model.profiles.getPerf("b0", "crit0").value_, 0.39);
+  EXPECT_FLOAT_EQ(model.profiles.getPerf("b0", "crit1").value_, 0.18);
 }
 
 TEST(TestProfileUpdater, TestOptimizeProfile) {

--- a/test/types/TestPerf.cpp
+++ b/test/types/TestPerf.cpp
@@ -23,21 +23,6 @@ TEST(TestPerf, TestConstructorByCopy) {
   EXPECT_EQ(os.str(), "Perf( name : test, crit : a, value : 0.6 )");
 }
 
-TEST(TestPerf, TestGetterSetter) {
-  Perf perf = Perf("test", "a", 0.6);
-  EXPECT_FLOAT_EQ(0.6, perf.getValue());
-  EXPECT_EQ("test", perf.getName());
-  EXPECT_EQ("a", perf.getCrit());
-
-  perf.setValue(0.4);
-  perf.setCrit("b");
-  perf.setName("test2");
-
-  EXPECT_FLOAT_EQ(0.4, perf.getValue());
-  EXPECT_EQ("test2", perf.getName());
-  EXPECT_EQ("b", perf.getCrit());
-}
-
 TEST(TestPerf, TestOperatorEqual) {
   Perf perf = Perf("test", "a", 0.6);
   Perf perf2 = Perf("test", "a", 0.6);

--- a/test/types/TestProfiles.cpp
+++ b/test/types/TestProfiles.cpp
@@ -91,24 +91,24 @@ TEST(TestProfiles, TestGetBelowAndAbove) {
   std::vector<Perf> below1 = profiles1.first;
   std::vector<Perf> above1 = profiles1.second;
 
-  EXPECT_EQ(below1[0].getName(), "b0");
-  EXPECT_EQ(above1[0].getName(), "b2");
+  EXPECT_EQ(below1[0].name_, "b0");
+  EXPECT_EQ(above1[0].name_, "b2");
 
   std::pair<std::vector<Perf>, std::vector<Perf>> profiles2 =
       profile.getBelowAndAboveProfile("b0", 0, 1);
   std::vector<Perf> below2 = profiles2.first;
   std::vector<Perf> above2 = profiles2.second;
 
-  EXPECT_EQ(below2[0].getName(), "base");
-  EXPECT_EQ(above2[0].getName(), "b1");
+  EXPECT_EQ(below2[0].name_, "base");
+  EXPECT_EQ(above2[0].name_, "b1");
 
   std::pair<std::vector<Perf>, std::vector<Perf>> profiles3 =
       profile.getBelowAndAboveProfile("b2", 0, 1);
   std::vector<Perf> below3 = profiles3.first;
   std::vector<Perf> above3 = profiles3.second;
 
-  EXPECT_EQ(below3[0].getName(), "b1");
-  EXPECT_EQ(above3[0].getName(), "top");
+  EXPECT_EQ(below3[0].name_, "b1");
+  EXPECT_EQ(above3[0].name_, "top");
 }
 
 TEST(TestProfiles, TestGetBelowAndAboveErrors) {
@@ -170,7 +170,7 @@ TEST(TestProfiles, TestSetPerfAndErrors) {
 
   profile.setPerf("b0", "crit1", 0.98);
 
-  EXPECT_FLOAT_EQ(profile.getPerf("b0", "crit1").getValue(), 0.98);
+  EXPECT_FLOAT_EQ(profile.getPerf("b0", "crit1").value_, 0.98);
 
   // TEST ERRORS
   try {


### PR DESCRIPTION
Getter and setters seemed to take quite a while in the profiling for Perf and Category, therefore I moved all args for these classes to public and removed the getter / setters of these methods.

Also removed unecessary copy of Perf in the ProfileInitialization algorithm